### PR TITLE
Fix: test execution terminates on non-unicode systems

### DIFF
--- a/test.rb
+++ b/test.rb
@@ -76,7 +76,8 @@ end
 tests.each do |test|
 #  puts Paint[test, :bright, :white]
   $cur_test = test
-  src = File.read test
+  file = File.open(test, "r:utf-8")
+  src = file.read
   
   parser = Twostroke::Parser.new(Twostroke::Lexer.new(src))
   parser.parse


### PR DESCRIPTION
After git clone I tried to run test by "ruby test.rb". But I execute on a Japanese Windows XP system and test suite terminates by encoding error in lexer.rb (line35) regex is UTF-8 but string is Windows-31J.
The issue is that input file format of test files is not set and default to system encoding is taken.
