### PR TITLE
Fix: Termination on non unicode system + gitignore redcar tmp file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+._*
 *.gem
 etc/
 coverage/

--- a/compile.rb
+++ b/compile.rb
@@ -1,7 +1,7 @@
 $LOAD_PATH << File.expand_path("../lib", __FILE__)
 require "twostroke"
-
-parser = Twostroke::Parser.new(Twostroke::Lexer.new(File.read ARGV.first))
+file = File.open(ARGV.first, "r:utf-8")
+parser = Twostroke::Parser.new(Twostroke::Lexer.new(file.read))
 parser.parse
 
 compiler = Twostroke::Compiler::TSASM.new parser.statements


### PR DESCRIPTION
Sorry for 2nd pull request. I'm getting a little tired.This is same issue as reported under issue #4 but this time it is in compile.rb .
Minor addition: Additionally I added 1 entry in .gitignore as this helps to ignore redcar editor tmp files.
